### PR TITLE
Fix error when running via direct command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-explicit-types",
   "displayName": "TypeScript Explicit Types",
   "description": "Generate explicit type annotation from inferred type in TypeScript",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "icon": "logo.png",
   "publisher": "nick-lvov-dev",
   "repository": "https://github.com/nick-lvov-dev/typescript-explicit-types",

--- a/src/actionProvider.ts
+++ b/src/actionProvider.ts
@@ -49,7 +49,7 @@ function executeSymbolProvider(uri: Uri) {
 // since type extraction depends on whether the definition is a function or not, there are some exceptions
 const functionHandlerExceptions = ['get'];
 
-export class GenereateTypeProvider implements CodeActionProvider {
+export class GenerateTypeProvider implements CodeActionProvider {
   public static readonly fixAllCodeActionKind = CodeActionKind.SourceFixAll.append('tslint');
 
   public static metadata: CodeActionProviderMetadata = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import { commands, DocumentFilter, ExtensionContext, languages } from 'vscode';
-import { GenereateTypeProvider } from './actionProvider';
+import { GenerateTypeProvider } from './actionProvider';
 import { commandHandler, commandId } from './command';
 
 export function activate(context: ExtensionContext) {
@@ -10,7 +10,7 @@ export function activate(context: ExtensionContext) {
   }
 
   const command = commands.registerCommand(commandId, commandHandler);
-  const codeActionProvider = languages.registerCodeActionsProvider(selector, new GenereateTypeProvider(), GenereateTypeProvider.metadata);
+  const codeActionProvider = languages.registerCodeActionsProvider(selector, new GenerateTypeProvider(), GenerateTypeProvider.metadata);
 
   context.subscriptions.push(command);
   context.subscriptions.push(codeActionProvider);


### PR DESCRIPTION
- Fixed a `Cannot read properties of undefined (reading '0')` error when running via the direct command
- Also fixed the spelling of GenereateTypeProvider to GenerateTypeProvider